### PR TITLE
Added player movement offsets for crash resolution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod game;
 mod graphics;
 mod player;
 
-use piston_window::*;
 use crate::game::Game;
+use piston_window::*;
 
 fn main() {
     // The dimensions of the game board, in "block" units.


### PR DESCRIPTION
Offset the movement times of each player so that there wouldn't be cases where both players are about to run into the same block at the same time.  Before, this just resulted in a random winner.